### PR TITLE
feat: add response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ No modules.
 | [aws_cloudfront_distribution.web_dist](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution) | resource |
 | [aws_cloudfront_distribution.web_redirect](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution) | resource |
 | [aws_cloudfront_origin_access_identity.origin_access_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_identity) | resource |
+| [aws_cloudfront_response_headers_policy.web_dist](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_response_headers_policy) | resource |
 | [aws_iam_role.lambda_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.lambda_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_lambda_function.redirect](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
@@ -77,6 +78,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cloudfront_origin_path"></a> [cloudfront\_origin\_path](#input\_cloudfront\_origin\_path) | Origin path of CloudFront | `string` | `""` | no |
+| <a name="input_content_security_policy"></a> [content\_security\_policy](#input\_content\_security\_policy) | Formatted CSP in string | `string` | `"default-src 'none';"` | no |
 | <a name="input_cors_allowed_origins"></a> [cors\_allowed\_origins](#input\_cors\_allowed\_origins) | CORS allowed origins | `list(string)` | `[]` | no |
 | <a name="input_domain_names"></a> [domain\_names](#input\_domain\_names) | domain names to serve site on | `list(string)` | n/a | yes |
 | <a name="input_enable_acm_validation"></a> [enable\_acm\_validation](#input\_enable\_acm\_validation) | Validates ACM by updating route 53 DNS | `bool` | `false` | no |
@@ -97,6 +99,9 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_aws_cloudfront_response_headers_policy_cors_config"></a> [aws\_cloudfront\_response\_headers\_policy\_cors\_config](#output\_aws\_cloudfront\_response\_headers\_policy\_cors\_config) | n/a |
+| <a name="output_aws_cloudfront_response_headers_policy_custom_headers_config"></a> [aws\_cloudfront\_response\_headers\_policy\_custom\_headers\_config](#output\_aws\_cloudfront\_response\_headers\_policy\_custom\_headers\_config) | n/a |
+| <a name="output_aws_cloudfront_response_headers_policy_security_headers_config"></a> [aws\_cloudfront\_response\_headers\_policy\_security\_headers\_config](#output\_aws\_cloudfront\_response\_headers\_policy\_security\_headers\_config) | n/a |
 | <a name="output_cache_invalidation_command"></a> [cache\_invalidation\_command](#output\_cache\_invalidation\_command) | CloudFront edge cache invalidation command. /path/to/invalidation/resource is like /index.html /error.html |
 | <a name="output_cache_invalidation_redirect_command"></a> [cache\_invalidation\_redirect\_command](#output\_cache\_invalidation\_redirect\_command) | CloudFront edge cache invalidation command. /path/to/invalidation/resource is like /index.html /error.html |
 | <a name="output_cloudfront_distribution_main_arn"></a> [cloudfront\_distribution\_main\_arn](#output\_cloudfront\_distribution\_main\_arn) | ARN of cloudfront distribution |

--- a/README.md
+++ b/README.md
@@ -20,6 +20,30 @@ You will have to run terraform import, e.g replace var.domain_name[0] with your 
 - `aws_s3_bucket_versioning`
 - `aws_s3_bucket_website_configuration`
 
+## Adding CSP headers
+
+X headers are returned by default, to customise the content security policy, format it in terraform and provide the full string to the variable `content_security_policy`
+
+```
+locals {
+  default-src = join(" ", ["default-src", "'none'"])
+  connect-src = join(" ", ["connect-src", "https://*.example.com"])
+  font-src = join(" ", ["font-src", "'self'"])
+  img-src = join(" ", ["img-src", "'self'"])
+  script-src = join(" ", ["script-src", "'self'"])
+  style-src = join(" ", ["style-src", "'self'", "'unsafe-inline'"])
+  object-src = join(" ", ["object-src", "'none'"])
+
+  content_security_policy = join( "; ", [local.default-src, local.connect-src, local.font-src, local.img-src, local.script-src, local.style-src, local.object-src])
+}
+
+module "cloudfront" {
+  ...
+  content_security_policy = local.content_security_policy
+  ...
+}
+```
+
 ## Requirements
 
 No requirements.

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -12,7 +12,6 @@ resource "aws_cloudfront_response_headers_policy" "web_dist" {
 
   security_headers_config {
     content_security_policy {
-      # content_security_policy = "default-src 'none'; connect-src https://*.supplyally.gov.sg; font-src 'self'; img-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; object-src 'none'"
       content_security_policy = var.content_security_policy
       override                = false
     }
@@ -55,7 +54,6 @@ resource "aws_cloudfront_distribution" "web_dist" {
   aliases             = var.domain_names
   web_acl_id          = var.web_acl_id
 
-
   origin {
     domain_name = aws_s3_bucket.main.bucket_regional_domain_name
     origin_id   = local.s3_origin_id
@@ -84,12 +82,12 @@ resource "aws_cloudfront_distribution" "web_dist" {
   }
 
   default_cache_behavior {
-    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
-    cached_methods   = ["GET", "HEAD", "OPTIONS"]
-    target_origin_id = local.s3_origin_id
-    compress         = true
-
+    allowed_methods            = ["GET", "HEAD", "OPTIONS"]
+    cached_methods             = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id           = local.s3_origin_id
+    compress                   = true
     response_headers_policy_id = aws_cloudfront_response_headers_policy.web_dist.id
+
     forwarded_values {
       query_string = var.forward_query_string
       headers      = ["Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers"]

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -7,6 +7,45 @@ resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {
   comment = "website"
 }
 
+resource "aws_cloudfront_response_headers_policy" "web_dist" {
+  name = "${var.service_name}-policy"
+
+  security_headers_config {
+    content_security_policy {
+      # content_security_policy = "default-src 'none'; connect-src https://*.supplyally.gov.sg; font-src 'self'; img-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; object-src 'none'"
+      content_security_policy = var.content_security_policy
+      override                = false
+    }
+
+    xss_protection {
+      mode_block = true
+      override   = false
+      protection = true
+    }
+
+    strict_transport_security {
+      access_control_max_age_sec = 63072000
+      include_subdomains         = true
+      override                   = false
+      preload                    = true
+    }
+
+    content_type_options {
+      override = false
+    }
+
+    referrer_policy {
+      referrer_policy = "same-origin"
+      override        = false
+    }
+
+    frame_options {
+      frame_option = "DENY"
+      override     = false
+    }
+  }
+}
+
 resource "aws_cloudfront_distribution" "web_dist" {
   enabled             = true
   is_ipv6_enabled     = true
@@ -15,6 +54,7 @@ resource "aws_cloudfront_distribution" "web_dist" {
   price_class         = "PriceClass_200"
   aliases             = var.domain_names
   web_acl_id          = var.web_acl_id
+
 
   origin {
     domain_name = aws_s3_bucket.main.bucket_regional_domain_name
@@ -49,6 +89,7 @@ resource "aws_cloudfront_distribution" "web_dist" {
     target_origin_id = local.s3_origin_id
     compress         = true
 
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.web_dist.id
     forwarded_values {
       query_string = var.forward_query_string
       headers      = ["Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers"]
@@ -76,11 +117,12 @@ resource "aws_cloudfront_distribution" "web_dist" {
     for_each = var.ordered_cache_behaviors
     iterator = behavior
     content {
-      path_pattern           = behavior.value["path"]
-      target_origin_id       = local.s3_origin_id
-      allowed_methods        = ["GET", "HEAD", "OPTIONS"]
-      cached_methods         = ["GET", "HEAD", "OPTIONS"]
-      viewer_protocol_policy = "redirect-to-https"
+      path_pattern               = behavior.value["path"]
+      target_origin_id           = local.s3_origin_id
+      allowed_methods            = ["GET", "HEAD", "OPTIONS"]
+      cached_methods             = ["GET", "HEAD", "OPTIONS"]
+      viewer_protocol_policy     = "redirect-to-https"
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.web_dist.id
 
       forwarded_values {
         query_string = var.forward_query_string

--- a/outputs.tf
+++ b/outputs.tf
@@ -97,3 +97,15 @@ output "s3_redirec_website_endpoint" {
 output "s3_redirect_website_domain" {
   value = aws_s3_bucket.redirect.website_domain
 }
+
+output "aws_cloudfront_response_headers_policy_cors_config" {
+  value = aws_cloudfront_response_headers_policy.web_dist.cors_config
+}
+
+output "aws_cloudfront_response_headers_policy_custom_headers_config" {
+  value = aws_cloudfront_response_headers_policy.web_dist.custom_headers_config
+}
+
+output "aws_cloudfront_response_headers_policy_security_headers_config" {
+  value = aws_cloudfront_response_headers_policy.web_dist.security_headers_config
+}

--- a/variables.tf
+++ b/variables.tf
@@ -91,3 +91,9 @@ variable "forward_query_string" {
   default     = false
   type        = bool
 }
+
+variable "content_security_policy" {
+  description = "Formatted CSP in string"
+  default     = "default-src 'none';"
+  type        = string
+}


### PR DESCRIPTION
This PR adds the ability to use content security policy to cloudfront distribution, therefore removing the need to use lambda@edge to return security headers anymore.

## terraform docs
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_response_headers_policy#content-security-policy