### PR TITLE
chore: add toggle to ttl

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -19,9 +19,9 @@ locals {
     allowed_methods            = ["GET", "HEAD", "OPTIONS"]
     cached_methods             = ["GET", "HEAD", "OPTIONS"]
     compress                   = var.enable_compression
-    default_ttl                = var.main_default_ttl
-    min_ttl                    = 0
-    max_ttl                    = 86400
+    default_ttl                = var.enable_ttl ? var.main_default_ttl : null
+    min_ttl                    = var.enable_ttl ? var.main_min_ttl : null
+    max_ttl                    = var.enable_ttl ? var.main_max_ttl : null
     viewer_protocol_policy     = "redirect-to-https"
     forward_query_string       = var.forward_query_string
     forward_headers           = ["Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers"]

--- a/variables.tf
+++ b/variables.tf
@@ -68,9 +68,27 @@ variable "permissions_boundary" {
   default     = ""
 }
 
+variable "enable_ttl" {
+  description = "Enable TTL settings for CloudFront cache. If false, uses origin cache settings."
+  type        = bool
+  default     = false
+}
+
 variable "main_default_ttl" {
-  description = "default TTL of the main cloudfront distribution"
-  default     = 180
+  description = "Default TTL of the main cloudfront distribution. Only used if enable_ttl is true."
+  default     = null
+  type        = number
+}
+
+variable "main_min_ttl" {
+  description = "Minimum TTL of the main cloudfront distribution. Only used if enable_ttl is true."
+  default     = null
+  type        = number
+}
+
+variable "main_max_ttl" {
+  description = "Maximum TTL of the main cloudfront distribution. Only used if enable_ttl is true."
+  default     = null
   type        = number
 }
 


### PR DESCRIPTION
# Make CloudFront TTL Settings Optional

## Overview
This PR introduces configurable TTL settings for CloudFront distributions, allowing users to either use origin cache settings or specify custom TTL values.

## Key Changes

### New Features
1. **Configurable TTL System**
   - New `enable_ttl` variable to toggle TTL settings (default: false)
   - When disabled, CloudFront uses origin cache settings
   - When enabled, allows custom TTL values

2. **New TTL Variables**
   - `main_default_ttl` (now optional, default: null)
   - `main_min_ttl` (new, default: null)
   - `main_max_ttl` (new, default: null)

### Breaking Changes
- Changed `main_default_ttl` from required (default: 180) to optional (default: null)
- TTL settings now default to origin cache settings instead of hardcoded values

## Usage Examples

### Using Origin Cache Settings (Default)
```hcl
module "website" {
  source = "terraform-s3-cloudfront-website"
  # TTL settings will use origin cache settings
}